### PR TITLE
typo fixes: 2022-11-07 Mastodon Hosting Part 1

### DIFF
--- a/content/rst/2022-11-07-mastodon-hosting-part-1.md
+++ b/content/rst/2022-11-07-mastodon-hosting-part-1.md
@@ -48,9 +48,9 @@ By midmorning the next day, we had again hit a significant backlog. It seems tha
 
 I looked into the logs of each component more closely and noticed that the database was rejecting a _lot_ of connections, as it would only permit a certain number of concurrent connections at any time. After a few hours of tweaking the queues to have the "right" pool size to try manage this, I took the [scaling guide's suggestion of pgbouncer](https://docs.joinmastodon.org/admin/scaling/#pgbouncer) to provide a buffer between the database and the systems using it. This helped reduce the number of errors in the course of steady state operations, but didn't mitigate the host slowdown because...
 
-### A Sirebar on Shared CPUs
+### A Sidebar on Shared CPUs
 
-I haven't gone and asked for confirmation of this, but after spending some time troubleshooting with [Andrew Certain](https://infosec.exchange/@tacertain) looking at performance numbers, we formed the hypothesis that the shared CPU nature of the instance was giving us misleading load numbers, and we were in fact fully exhausing the CPU we had available despite appearing to be only at 70%.
+I haven't gone and asked for confirmation of this, but after spending some time troubleshooting with [Andrew Certain](https://infosec.exchange/\@tacertain) looking at performance numbers, we formed the hypothesis that the shared CPU nature of the instance was giving us misleading load numbers, and we were in fact fully exhausting the CPU we had available despite appearing to be only at 70%.
 
 The only way out of this was either to optimze the Mastodon code -- and that's not off the table! -- or to offload some work.
 


### PR DESCRIPTION
Just a couple of trivial typo corrections and one Markdown-escaped `@` to hopefully fix an issue with rendering a link to a Mastodon user account.  (I don't have a Pelican installation handy to test so I'm afraid I can't guarantee that backslashing the `@` is sufficient to resolve the symptom.  🤞😬🤞)